### PR TITLE
Updated README with prebuilt images and fixed/updated docker-compose.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ XMR
 
 ### Docker
 
+Prebuilt image:
+
+Docker run
+```
+docker run --name=cryptohttp -d -v "$pwd":/app/config -p 8080:8080 --restart unless-stopped ackr8/cryptohttp
+```
+Docker compose
+```
+version: '3.3'
+services:
+    cryptohttp:
+        container_name: cryptohttp
+        volumes:
+            - '$pwd:/app/config'
+        ports:
+            - '8080:8080'
+        restart: unless-stopped
+        image: ackr8/cryptohttp
+```
+
+Manually building the image:
+
 ```
 git clone https://github.com/jakedolan443/cryptohttp
 cd cryptohttp

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,10 +3,10 @@ services:
   cryptohttp:
     container_name: cryptohttp
     environment:
-      PORT: 8000
+      PORT: 8080
     image: cryptohttp
     ports:
-      - "8080:8000"
+      - "8080:8080"
     restart: unless-stopped
     volumes:
       - /config:/app/config


### PR DESCRIPTION
Hey I made prebuilt images of cryptohttp for docker as well as kubernetes, I have added the instructions in the readme. Also I updated the docker compose so that the default port is 8080 instead of the previous 8000.